### PR TITLE
substituindo RP para Recife

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Ramo local do PyLadies cujo objetivo é propagar em Ribeirão Preto e região os ideais das PyLadies e da comunidade Python.">
-    <meta name="author" content="PyLadies RP">
+    <meta name="description" content="Ramo local do PyLadies cujo objetivo é propagar em Recife e região os ideais das PyLadies e da comunidade Python.">
+    <meta name="author" content="PyLadies Recife">
 
-    <title> PyLadies RP</title>
+    <title> PyLadies Recife</title>
     <link rel="shortcut icon" type="image/png" href="img/pyladies-rec.png" />
 
     <!-- Bootstrap Core CSS -->
@@ -85,7 +85,7 @@
             <div class="intro-text" style="padding-top: 100px;">
                 <div class="intro-heading" style= "font-family: 'Kaushan Script','Helvetica Neue',Helvetica,Arial,cursive; text-transform: capitalize; color: #A52323; ">
                     <img class="img-responsive" src="img/pyladies.png" alt="" style="width:60%; margin: auto;">
-                    <h1 style= "font-family: 'Kaushan Script','Helvetica Neue',Helvetica,Arial, cursive; text-transform: capitalize; color: #A52323; font-size: 0.7em">Ribeirão Preto</h1>
+                    <h1 style= "font-family: 'Kaushan Script','Helvetica Neue',Helvetica,Arial, cursive; text-transform: capitalize; color: #A52323; font-size: 0.7em">Recife</h1>
                 </div>
                 <div class="intro-lead-in" style="text-shadow: 2px 2px 2px #777;">
                   Apoiando mulheres na área de tecnologia
@@ -105,7 +105,7 @@
             sarahjstauber/replace-logo
             <div class="clearfix"></div>
             <h2 class="section-heading" style= "font-family: 'Kaushan Script','Helvetica Neue',Helvetica,Arial,cursive; text-transform: capitalize; color: #A52323; ">Sobre</h2>
-            <p class="lead" style="font-size: 15px">PyLadies RP recebe <i>Ladies</i> (e aqueles que se identificam como tais) de toda Ribeirão Preto e região. </p>
+            <p class="lead" style="font-size: 15px">PyLadies Recife recebe <i>Ladies</i> (e aqueles que se identificam como tais) de toda Recife e região. </p>
             <br>
             <p class="lead" style="font-size: 19px">PyLadies é um grupo de mentoria internacional com foco em ajudar mais mulheres a se tornarem participantes ativas e líderes na comunidade Python.</p>
             <p class="lead" style="font-size: 19px">Nossa missão é promover, educar e incentivar uma comunidade Python diversificada através de divulgação, educação, conferências, eventos e encontros sociais.</p>
@@ -138,11 +138,11 @@
               <a href="#" target="blank" class="events-link">
                 <div class="events-caption">
                   <i class="fa fa-calendar fa-3x"></i>
-                  <h6> Pyadies-RP Week</h6>
+                  <h6> Pyadies-Recife Week</h6>
                   <p class="text-muted">De 23 à 26 de Maio de 2018</p>
                   <p class="text-muted"> Palestras na Universidade de São Paulo e Django Girls na Crave Foods Systems</p>
                   <div class="event-info">
-                    <p>O Pyladies-RP Week é uma iniciativa do grupo de Pyladies-RP com o objetivo de inspirar mais mulheres a entrar na área de tecnologia.erá um evento de 4 dias, onde nos 3 primeiros dias traremos mulheres inspiradoras  para palestrar sobre Python, empoderamento feminino e empreendedorismo.  E no último dia, finalizaremos com chave de ouro, oferecendo a oficina que faz mais sucesso nesse Brasil: Django Girls - RP Segunda Edição S2 </p>
+                    <p>O Pyladies-Recife Week é uma iniciativa do grupo de Pyladies-Recife com o objetivo de inspirar mais mulheres a entrar na área de tecnologia.erá um evento de 4 dias, onde nos 3 primeiros dias traremos mulheres inspiradoras  para palestrar sobre Python, empoderamento feminino e empreendedorismo.  E no último dia, finalizaremos com chave de ouro, oferecendo a oficina que faz mais sucesso nesse Brasil: Django Girls - Recife Segunda Edição S2 </p>
                   </div>
                 </div>
               </a>
@@ -182,7 +182,7 @@
                   <i class="fa fa-calendar fa-3x"></i>
                   <h6>Programação não é só coisa de meninos!</h6>
                   <p class="text-muted">21 de Setembro de 2016</p>
-                  <p class="text-muted"> Universidade de São Paulo - Ribeirão Preto</p>
+                  <p class="text-muted"> Universidade de São Paulo - Recife</p>
                   <div class="event-info">
                     <p>Você sabia que a primeira pessoa a escrever um código foi uma mulher? Venha participar e descobrir o quão importante mulheres são no mundo da computação!</p>
                   </div>
@@ -199,7 +199,7 @@
       <div class="container" style="padding-top: 10px;" >
         <div class="row">
           <div class="col-lg-12 text-center" style="padding-bottom: 30px;">
-            <h2 class="section-heading" style= "font-family: 'Kaushan Script','Helvetica Neue',Helvetica,Arial,cursive; text-transform: capitalize; color: #A52323;">Integrantes do Pyladies Ribeirão Preto</h2>
+            <h2 class="section-heading" style= "font-family: 'Kaushan Script','Helvetica Neue',Helvetica,Arial,cursive; text-transform: capitalize; color: #A52323;">Integrantes do Pyladies Recife</h2>
           </div>
         </div>
         <div class="row text-center">
@@ -350,16 +350,16 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-4">
-                    <span class="copyright">Copyright &copy; PyLadies RP 2016</span>
+                    <span class="copyright">Copyright &copy; PyLadies Recife 2016</span>
                 </div>
                 <div class="col-md-4">
                     <ul class="list-inline social-buttons">
 
-                        <li><a href="https://www.facebook.com/pyladiesrp/" target="_blank"><i class="fa fa-facebook"></i></a>
+                        <li><a href="https://pt-br.facebook.com/pyladiesrecife/" target="_blank"><i class="fa fa-facebook"></i></a>
                         </li>
                         <!-- <li><a href="#"><i class="fa fa-linkedin" target="_blank"></i></a> -->
                         <!-- </li> -->
-                        <li><a href="https://github.com/pyladies-rp/" target="_blank"><i class="fa fa-github-square"></i></a>
+                        <li><a href="https://github.com/pyladiesrecife" target="_blank"><i class="fa fa-github-square"></i></a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
substituindo onde está escrito Ribeirão Preto ou RP para Recife, em textos e links de contatos. Closses #50 .